### PR TITLE
Fix: Correct GitHub Pages deployment URL and clean up configuration.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>It works!</title>
-</head>
-<body>
-  <h1>Hello from GitHub Pages</h1>
-</body>
-</html>

--- a/package.json
+++ b/package.json
@@ -3,15 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://ryand2626.github.io/jack-mack-artisan-shop",
+  "homepage": "https://lucid-directions.github.io/jack-mack-artisan-shop/",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -b gh-pages -d dist"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
- I updated `package.json` homepage to point to lucid-directions GitHub organization.
- I removed manual deployment scripts (`predeploy`, `deploy`) from `package.json` to rely on GitHub Actions.
- I deleted unused `docs/index.html` to prevent confusion.

These changes ensure your Vite application builds with the correct base URL for assets and that the GitHub Actions workflow deploys to the intended GitHub Pages site.